### PR TITLE
bastille support

### DIFF
--- a/src/tasks/greyyou.ts
+++ b/src/tasks/greyyou.ts
@@ -795,6 +795,12 @@ export function GyouQuest(): Quest {
         do: () => use($item`chest of the Bonerdagon`),
       },
       {
+        name: "Bastille Battalion",
+        ready: () => have($item`Bastille Battalion control rig`),
+        completed: () => get("_bastilleGames") !== 0,
+        do: () => cliExecute("bastille mainstat draftsman gesture"),
+      },
+      {
         name: "Steel Margarita",
         ready: () => haveAll($items`Azazel's tutu, Azazel's lollipop, Azazel's unicorn`),
         completed: () => have($skill`Liver of Steel`) || have($item`steel margarita`),


### PR DESCRIPTION
Bastille script is already a dependency for garbo, so everyone should already have it. Great news!

Otherwise you saw reasoning in discord. Mainstat for leveling. Meat buff for embezzlers after leveling. + RO Adv asc as more generally good than fam weight for folks. High contention for asc slots when farming, so farm weight won't be ran much

As a side note, it is really nice that we have a common framework for scripts now. Copy/pasted this out of garbo and adjusted the script call to what we wanted.

I tested the script command `bastille mainstat draftsman gesture` works in the aftercore leg. Running goorbo now, will update to confirm works after prism break