### PR TITLE
Leveling improvements

### DIFF
--- a/src/tasks/aftercore.ts
+++ b/src/tasks/aftercore.ts
@@ -218,20 +218,7 @@ export function AftercoreQuest(): Quest {
         }),
         combat: new CombatStrategy().macro(() =>
           Macro.tryItem($item`gas balloon`)
-            .externalIf(
-              have($skill`Feel Pride`) && get("_feelPrideUsed") < 3,
-              Macro.trySkill($skill`Feel Pride`),
-              Macro.externalIf(
-                $familiar`Grey Goose`.experience >= 400,
-                Macro.trySkill(
-                  myPrimestat() === $stat`Muscle`
-                    ? $skill`Convert Matter to Protein`
-                    : myPrimestat() === $stat`Mysticality`
-                    ? $skill`Convert Matter to Energy`
-                    : $skill`Convert Matter to Pomade`
-                )
-              )
-            )
+            .trySkill($skill`Feel Pride`)
             .tryItem(...$items`shard of double-ice, gas can`)
             .attack()
             .repeat()

--- a/src/tasks/greyyou.ts
+++ b/src/tasks/greyyou.ts
@@ -895,10 +895,7 @@ export function GyouQuest(): Quest {
         }),
         combat: new CombatStrategy().macro(() =>
           Macro.tryItem($item`gas balloon`)
-            .externalIf(
-              have($skill`Feel Pride`) && get("_feelPrideUsed") < 3,
-              Macro.trySkill($skill`Feel Pride`)
-            )
+            .trySkill($skill`Feel Pride`)
             .tryItem(...$items`shard of double-ice, gas can`)
             .attack()
             .repeat()
@@ -1145,10 +1142,7 @@ export function GyouQuest(): Quest {
             )
             .tryItem(...$items`porquoise-handled sixgun, HOA citation pad`)
             .trySkill($skill`Sing Along`)
-            .externalIf(
-              have($skill`Feel Pride`) && get("_feelPrideUsed") < 3,
-              Macro.trySkill($skill`Feel Pride`)
-            )
+            .externalIf(myLevel() >= args.targetlevel - 2, Macro.trySkill($skill`Feel Pride`))
             .attack()
             .repeat()
         ),
@@ -1217,10 +1211,7 @@ export function GyouQuest(): Quest {
             )
             .tryItem($item`porquoise-handled sixgun`)
             .trySkill($skill`Sing Along`)
-            .externalIf(
-              have($skill`Feel Pride`) && get("_feelPrideUsed") < 3,
-              Macro.trySkill($skill`Feel Pride`)
-            )
+            .externalIf(myLevel() >= args.targetlevel - 2, Macro.trySkill($skill`Feel Pride`))
             .trySkill($skill`Fire the Jokester's Gun`)
             .trySkill($skill`Chest X-Ray`)
             .trySkill($skill`Gingerbread Mob Hit`)

--- a/src/tasks/greyyou.ts
+++ b/src/tasks/greyyou.ts
@@ -1122,6 +1122,10 @@ export function GyouQuest(): Quest {
               Macro.tryItem($item`electronics kit`)
             )
             .externalIf(
+              get("cosmicBowlingBallReturnCombats") < 1,
+              Macro.trySkill($skill`Bowl Sideways`)
+            )
+            .externalIf(
               $familiar`Grey Goose`.experience >= 400,
               Macro.trySkill(
                 myPrimestat() === $stat`Muscle`
@@ -1188,6 +1192,10 @@ export function GyouQuest(): Quest {
               have($skill`Curse of Weaksauce`),
               Macro.trySkill($skill`Curse of Weaksauce`),
               Macro.tryItem($item`electronics kit`)
+            )
+            .externalIf(
+              get("cosmicBowlingBallReturnCombats") < 1,
+              Macro.trySkill($skill`Bowl Sideways`)
             )
             .externalIf(
               $familiar`Grey Goose`.experience >= 400,

--- a/src/tasks/greyyou.ts
+++ b/src/tasks/greyyou.ts
@@ -1133,6 +1133,10 @@ export function GyouQuest(): Quest {
             )
             .tryItem(...$items`porquoise-handled sixgun, HOA citation pad`)
             .trySkill($skill`Sing Along`)
+            .externalIf(
+              have($skill`Feel Pride`) && get("_feelPrideUsed") < 3,
+              Macro.trySkill($skill`Feel Pride`)
+            )
             .attack()
             .repeat()
         ),
@@ -1197,6 +1201,10 @@ export function GyouQuest(): Quest {
             )
             .tryItem($item`porquoise-handled sixgun`)
             .trySkill($skill`Sing Along`)
+            .externalIf(
+              have($skill`Feel Pride`) && get("_feelPrideUsed") < 3,
+              Macro.trySkill($skill`Feel Pride`)
+            )
             .trySkill($skill`Fire the Jokester's Gun`)
             .trySkill($skill`Chest X-Ray`)
             .trySkill($skill`Gingerbread Mob Hit`)


### PR DESCRIPTION
Uses `Feel Pride` for NEP and gators. 

Also uses `bowl sideways` opportunistically in NEP and gators. If it is available, use it. Leaving it to a future PR to fully support the bowling ball (stop using bowl straight up in time to use sideways for leveling)

Tested today and both are working for NEP. Pride properly got used when available and stopped attempting when used up for the day. Got to 13 before going to gators so didn't test that but I think low risk