### PR TITLE
Autumnaton Support

### DIFF
--- a/src/tasks/greyyou.ts
+++ b/src/tasks/greyyou.ts
@@ -67,12 +67,14 @@ import {
   $item,
   $items,
   $location,
+  $locations,
   $monster,
   $monsters,
   $phylum,
   $skill,
   $stat,
   AsdonMartin,
+  AutumnAton,
   DNALab,
   ensureEffect,
   get,
@@ -226,6 +228,33 @@ export function GyouQuest(): Quest {
         },
         outfit: () => ({ equip: $items`June cleaver` }),
         limit: undefined,
+      },
+      {
+        name: "Autumnaton",
+        completed: () =>
+          !have($item`autumn-aton`) || AutumnAton.turnsForQuest() >= myAdventures() + 10,
+        do: () => {
+          if (
+            itemAmount($item`imp air`) < 5 &&
+            !have($skill`Liver of Steel`) &&
+            !have($item`steel margarita`) &&
+            !have($item`Azazel's tutu`)
+          ) {
+            AutumnAton.sendTo($location`The Laugh Floor`);
+          }
+          if (
+            itemAmount($item`bus pass`) < 5 &&
+            !have($skill`Liver of Steel`) &&
+            !have($item`steel margarita`) &&
+            !have($item`Azazel's tutu`)
+          ) {
+            AutumnAton.sendTo($location`Infernal Rackets Backstage`);
+          }
+          const autumnAtonZones = $locations`The Toxic Teacups, The Oasis, The Deep Dark Jungle, The Bubblin' Caldera, The Sleazy Back Alley`;
+          if (AutumnAton.turnsForQuest() < myAdventures() + 10) {
+            AutumnAton.sendTo(autumnAtonZones);
+          }
+        },
       },
       {
         name: "Meat Boombox",


### PR DESCRIPTION
Goes to get imp air and bus pass if we don't have enough already. Then copied locations from garbo. 

Tested today and worked well. Did the Laugh Floor, then Infernal Rackets Backstage, then Oasis. So only did 3 quests. 

Garbo's preferred location is The Toxic Teacups but I think we would need to place a wander there to allow the bot to quest there. Didn't bother with doing that since only did a single quest at oasis. But definitely something that could be improved later.