### PR TITLE
Upgrade libram to 0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "core-js": "^3.16.4",
     "grimoire-kolmafia": "^0.3.9",
     "kolmafia": "^5.26911.0",
-    "libram": "^0.7.4",
+    "libram": "^0.7.6",
     "typescript-eslint": "^0.0.1-alpha.0"
   },
   "author": "frazazel",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,10 +2254,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libram@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/libram/-/libram-0.7.4.tgz#ce3cfb5c52133e161bbf738b490ca576a38e743c"
-  integrity sha512-dLTwHVy9DR8nosCrWNijja7B1RTNIJCktAGscMRGPCvz/1ZSXaLjYrSbO72m4TesjzckBAXlVaEfUFgVyZiLug==
+libram@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/libram/-/libram-0.7.6.tgz#e63cff60d4d0ffc54f40280da8e751ce41245d56"
+  integrity sha512-urkfZ/jyk5M3/0Xe503W3GF/Ay8cCXTAivhTx8YwYfdtcW5Y9E+7G3K3GiKjgbKvQ+OFcCb9KMRjc6tAlVSWlQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.17.2"
     core-js "^3.21.0"


### PR DESCRIPTION
Libram 0.7.6 just got cut and it included the change I made to make ascension work when using compact character pane. I confirmed this afternoon that it works:
```
> Executing Aftercore/Ascend Grey You
> Current Perm Plan: bank karma - Class: Seal Clubber, Expected Karma: 157
> Next Perm Plan: bank karma - Class: Disco Bandit, Expected Karma: 257
Preference goorboNextClass changed from  to Disco Bandit

ascend.php?action=ascend&confirm=on&confirm2=on
Preference lastBreakfast changed from -1 to 0
Preference _concoctionDatabaseRefreshes changed from 810 to 811

Welcome to Valhalla!
[... snipped a million preference resets...]
You have 57 banked Karma.
You gain 111 Karma
Your new Karma balance is 168
Preference bankedKarma changed from 57 to 168

Buy astral six-pack for 1 Karma (initial balance = 168)
Preference bankedKarma changed from 168 to 167
You spend 1 Karma

Buy astral pet sweater for 10 Karma (initial balance = 167)
Preference bankedKarma changed from 167 to 157
You spend 10 Karma

Ascend as a Normal Female Grey Goo under the Vole sign on a Grey You path, banking 157 Karma.
Preference lastEncounter changed from angry tourist to Your Friend Goo
Encounter: Your Friend Goo
Took choice 1464/1: Goo...d
choice.php?whichchoice=1464&option=1&pwd
[... snipped more preference resets...]

inventory.php?reminisce=1
Preference lastBattlefieldReset changed from 68 to 69
Preference _concoctionDatabaseRefreshes changed from 5 to 6


=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
	   Beginning New Ascension	     
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

Ascension #69:
Softcore Grey You Grey Goo
Vole
```