### PR TITLE
Verbose profit recording

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -70,7 +70,7 @@ export class ProfitTrackingEngine extends Engine<never, Task> {
     try {
       super.execute(task);
     } finally {
-      this.profits.record(`${getCurrentLeg()}@${task.tracking ?? "Other"}`);
+      this.profits.record(`${getCurrentLeg()}@${task.tracking ?? "Other"}`, task.name);
     }
   }
 

--- a/src/engine/profits.ts
+++ b/src/engine/profits.ts
@@ -240,7 +240,7 @@ export class ProfitTracker {
     );
   }
 
-  record(tag: string): void {
+  record(tag: string, taskName: string): void {
     if (this.ascensions < myAscensions()) {
       // Session tracking is not accurate across ascensions
       this.reset();
@@ -270,7 +270,7 @@ export class ProfitTracker {
     this.records[tag].turns += myTurncount() - this.turns;
     this.records[tag].hours += gametimeToInt() / (1000 * 60 * 60) - this.hours;
     print(
-      `Profit: ${value.meat}, ${value.items}, ${myTurncount() - this.turns}, ${
+      `Profit for ${taskName}:${value.meat}, ${value.items}, ${myTurncount() - this.turns}, ${
         gametimeToInt() / (1000 * 60 * 60) - this.hours
       }`
     );

--- a/src/engine/profits.ts
+++ b/src/engine/profits.ts
@@ -270,7 +270,7 @@ export class ProfitTracker {
     this.records[tag].turns += myTurncount() - this.turns;
     this.records[tag].hours += gametimeToInt() / (1000 * 60 * 60) - this.hours;
     print(
-      `Profit for ${taskName}:${value.meat}, ${value.items}, ${myTurncount() - this.turns}, ${
+      `Profit for ${taskName}: ${value.meat}, ${value.items}, ${myTurncount() - this.turns}, ${
         gametimeToInt() / (1000 * 60 * 60) - this.hours
       }`
     );


### PR DESCRIPTION
Currently each task record profit (both positive and negative). However it doesn't record the task name. While looking at surrounding section of the log can tell us what task was being ran, just recording the task with the profit makes it easier.

Example log entry before
` > Profit: -42000, 0, 0, 0.0002777777777787094`

Example log entry now
`> Profit for Grey You/Stillsuit Prep:0, 0, 0, 0.0002777777777787094`