### PR TITLE
Make clockwork maid purchase optional

### DIFF
--- a/src/tasks/greyyou.ts
+++ b/src/tasks/greyyou.ts
@@ -1611,12 +1611,16 @@ export function GyouQuest(): Quest {
       },
       {
         name: "Pajamas",
-        completed: () => args.ascend || getCampground()[$item`clockwork maid`.name] === 1,
+        completed: () => args.ascend || have($item`burning cape`),
         acquire: [
-          { item: $item`clockwork maid`, price: 7 * get("valueOfAdventure") },
+          { item: $item`clockwork maid`, price: 7 * get("valueOfAdventure"), optional: true },
           { item: $item`burning cape` },
         ],
-        do: () => use($item`clockwork maid`),
+        do: () => {
+          if (have($item`clockwork maid`)) {
+            use($item`clockwork maid`);
+          }
+        },
         outfit: () => ({
           familiar:
             $familiars`Trick-or-Treating Tot, Left-Hand Man, Disembodied Hand, Grey Goose`.find(


### PR DESCRIPTION
Clockwork maids have become more expensive, so goorbo is failing at Pajamas for people with lower valueOfAdventure. Let's use grimoire's `optional` arg and adjust the completion condition slightly so it doesn't re-run in the case that you don't get a maid.

Example logs before this change:
```
Executing Grey You/Pajamas
Searching for "clockwork maid"...
Search complete.
Desired purchase quantity not reached (wanted 1, got 0)
Profit for Grey You/Pajamas: 0, 0, 0, 0.00027777777777515666
[...snipped...]
JavaScript exception: Task Grey You/Pajamas was unable to acquire 1 clockwork maid (file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js#7897)
at file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js:7897 (f)
at file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js:8114 (acquireItems)
at file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js:8035 (execute)
at file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js:12893 (execute)
at file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js:7972 (run)
at file:/Users/user/Library/Application%20Support/KoLmafia/scripts/goorbo/goorbo.js:12968 (main)
```

Example logs after the change:
```
Executing Grey You/Pajamas
Searching for "clockwork maid"...
Search complete.
Desired purchase quantity not reached (wanted 1, got 0)
Verifying ingredients for burning cape (1)...
Creating 1 burning cape...
You lose 1 hit point
You acquire an item: burning cape
Preference _concoctionDatabaseRefreshes changed from 2078 to 2079
Successfully created burning cape (1)
Valuing burning newspaper @ 900
Valuing burning cape @ 0
Profit for Grey You/Pajamas: 0, -900, 0, 0.0002777777777787094
[...snipped rest of successful output...]
```